### PR TITLE
서버를 실행하고 e2e 테스트를 실행하는 도커 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Versioning and metadata
+.git
+.gitignore
+.dockerignore
+
+# Build dependencies
+dist
+node_modules
+coverage
+
+# Environment (contains sensitive data)
+.env
+.env.*
+
+# Files not required for production
+Dockerfile
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# environment variables
+.env
+.env.test

--- a/docker-compose.e2e-test.yml
+++ b/docker-compose.e2e-test.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_DB=test
+      - POSTGRES_USER=test
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_INITDB_ARGS=--encoding=UTF-8
+
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/development/Dockerfile
+    env_file:
+      - .env.test
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+    command:
+      - bash
+      - -c
+      - |
+        npm run test:e2e
+    volumes:
+      - ./:/app/

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_INITDB_ARGS=--encoding=UTF-8
+
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/development/Dockerfile
+    env_file:
+      - .env
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+    command:
+      - bash
+      - -c
+      - |
+        npm run start:dev
+    volumes:
+      - ./:/app/

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/production/Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:18-alpine3.18
+
+# Korean Fonts
+RUN apk --update add fontconfig
+RUN mkdir -p /usr/share/fonts/nanumfont
+RUN wget http://cdn.naver.com/naver/NanumFont/fontfiles/NanumFont_TTF_ALL.zip
+RUN unzip NanumFont_TTF_ALL.zip -d /usr/share/fonts/nanumfont
+RUN fc-cache -f && rm -rf /var/cache/*
+
+# bash install
+RUN apk add bash
+
+# Language
+ENV LANG=ko_KR.UTF-8 \
+    LANGUAGE=ko_KR.UTF-8
+
+# Set the timezone in docker
+RUN apk --no-cache add tzdata && \
+        cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+        echo "Asia/Seoul" > /etc/timezone
+
+# Create Directory for the Container
+WORKDIR /app
+
+# Only copy the package.json file to work directory
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . ./
+
+# Docker Demon Port Mapping
+EXPOSE 3000

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:18-alpine3.18 as builder
+
+ENV NODE_ENV build
+
+USER node
+WORKDIR /home/node
+
+COPY ../../package*.json ./
+RUN npm ci
+
+COPY --chown=node:node ../.. .
+RUN npm run build \
+    && npm prune --production
+
+# ---
+
+FROM node:18-alpine3.18
+
+ENV NODE_ENV production
+
+USER node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /home/node/package*.json ./
+COPY --from=builder --chown=node:node /home/node/node_modules/ ./node_modules/
+COPY --from=builder --chown=node:node /home/node/dist/ ./dist/
+
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## 개요(문제 요약)
- 도커로 서버를 실행하고 e2e 테스트를 실행할 수 있게 도커파일 추가

## 작업 사항
- production, local, e2e-test 로 나눠서 추가했어요
- production은 https://github.com/Saluki/nestjs-template/blob/master/Dockerfile 를 많이 참고했어요 (거의 똑같아요)
- local, e2e-test는 https://jojoldu.tistory.com/587를 많이 참고했어요.

## 참고 사항
- 프로젝트 root 경로에 .env, .env.test 파일이 비어있더라도 있어야돼요!